### PR TITLE
Add overlay navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,39 +37,19 @@
         <span aria-hidden="true" class="menu-overlay__close-icon"></span>
       </button>
       <nav class="menu-overlay__nav" aria-labelledby="site-menu-title">
-        <h2 class="menu-overlay__title" id="site-menu-title">Classnoe Mesto</h2>
-        <p class="menu-overlay__subtitle">Навигация по пространству</p>
+        <h2 class="visually-hidden" id="site-menu-title">Навигация</h2>
         <ul class="menu-overlay__list">
           <li>
-            <a class="menu-overlay__link" href="#intro" data-menu-link data-menu-initial-focus>О месте</a>
+            <a class="menu-overlay__link" href="#menu" data-menu-link data-menu-initial-focus>Меню</a>
           </li>
           <li>
-            <a
-              class="menu-overlay__link"
-              href="https://example.com/classnoe-mesto-menu.pdf"
-              target="_blank"
-              rel="noopener"
-              data-menu-link
-            >
-              Меню (PDF)
-              <span class="menu-overlay__note" aria-hidden="true">Откроется в новой вкладке</span>
-              <span class="visually-hidden"> (откроется в новой вкладке)</span>
-            </a>
+            <a class="menu-overlay__link" href="#booking" data-menu-link>Бронь</a>
           </li>
           <li>
-            <a
-              class="menu-overlay__link"
-              href="https://maps.google.com/?q=Classnoe+Mesto"
-              target="_blank"
-              rel="noopener"
-              data-menu-link
-            >
-              Адрес
-              <span class="visually-hidden"> (откроется в новой вкладке)</span>
-            </a>
+            <a class="menu-overlay__link" href="#history" data-menu-link>История</a>
           </li>
           <li>
-            <a class="menu-overlay__link" href="mailto:hello@classnoemesto.example" data-menu-link>Контакты</a>
+            <a class="menu-overlay__link" href="#contacts" data-menu-link>Контакты</a>
           </li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ru">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,8 +11,7 @@
   <meta name="theme-color" content="#1c1c1c" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
@@ -74,8 +73,7 @@
   <script>
     // === EDIT TEXT HERE (English copy) ===
     const SENTENCES = [
-      "Мы начали с вопроса, который беспокоил нас самих: что действительно нужно человеку?",
-      "Не каждому. Только тем, кто выбирает ясность вместо шума.",
+      "Мы начали с вопроса, который беспокоил нас самих: что действительно нужно человеку? Не каждому. Только тем, кто выбирает ясность вместо шума.",
       "Будущее дало ответ: энергия, фокус, равновесие.",
       "Мы верим, что спокойствие и явность — это новая роскошь. Жизнь можно проектировать. Здоровье и фокус — это не случайность, а выбор, который вы делаете каждый день.",
       "Раньше люди искали смысл. Сегодня мы ищем фокус."

--- a/index.html
+++ b/index.html
@@ -15,6 +15,67 @@
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
+  <button
+    class="menu-toggle"
+    type="button"
+    aria-controls="site-menu"
+    aria-expanded="false"
+    data-menu-toggle
+  >
+    <span class="menu-toggle__icon" aria-hidden="true">
+      <span class="menu-toggle__bar"></span>
+      <span class="menu-toggle__bar"></span>
+      <span class="menu-toggle__bar"></span>
+    </span>
+    <span class="visually-hidden" data-menu-toggle-label>Открыть меню</span>
+  </button>
+
+  <div class="menu-overlay" id="site-menu" data-menu-overlay aria-hidden="true">
+    <div class="menu-overlay__surface" role="dialog" aria-modal="true" aria-labelledby="site-menu-title">
+      <button class="menu-overlay__close" type="button" data-menu-close>
+        <span class="visually-hidden">Закрыть меню</span>
+        <span aria-hidden="true" class="menu-overlay__close-icon"></span>
+      </button>
+      <nav class="menu-overlay__nav" aria-labelledby="site-menu-title">
+        <h2 class="menu-overlay__title" id="site-menu-title">Classnoe Mesto</h2>
+        <p class="menu-overlay__subtitle">Навигация по пространству</p>
+        <ul class="menu-overlay__list">
+          <li>
+            <a class="menu-overlay__link" href="#intro" data-menu-link data-menu-initial-focus>О месте</a>
+          </li>
+          <li>
+            <a
+              class="menu-overlay__link"
+              href="https://example.com/classnoe-mesto-menu.pdf"
+              target="_blank"
+              rel="noopener"
+              data-menu-link
+            >
+              Меню (PDF)
+              <span class="menu-overlay__note" aria-hidden="true">Откроется в новой вкладке</span>
+              <span class="visually-hidden"> (откроется в новой вкладке)</span>
+            </a>
+          </li>
+          <li>
+            <a
+              class="menu-overlay__link"
+              href="https://maps.google.com/?q=Classnoe+Mesto"
+              target="_blank"
+              rel="noopener"
+              data-menu-link
+            >
+              Адрес
+              <span class="visually-hidden"> (откроется в новой вкладке)</span>
+            </a>
+          </li>
+          <li>
+            <a class="menu-overlay__link" href="mailto:hello@classnoemesto.example" data-menu-link>Контакты</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
   <!-- Intro screen: centered title that scrolls away naturally -->
   <section id="intro" aria-label="Intro">
     <h1>Classnoe Mesto</h1>

--- a/index.html
+++ b/index.html
@@ -30,30 +30,32 @@
     <span class="visually-hidden" data-menu-toggle-label>Открыть меню</span>
   </button>
 
-  <div class="menu-overlay" id="site-menu" data-menu-overlay aria-hidden="true">
-    <div class="menu-overlay__surface" role="dialog" aria-modal="true" aria-labelledby="site-menu-title">
-      <button class="menu-overlay__close" type="button" data-menu-close>
-        <span class="visually-hidden">Закрыть меню</span>
-        <span aria-hidden="true" class="menu-overlay__close-icon"></span>
-      </button>
-      <nav class="menu-overlay__nav" aria-labelledby="site-menu-title">
-        <h2 class="visually-hidden" id="site-menu-title">Навигация</h2>
-        <ul class="menu-overlay__list">
-          <li>
-            <a class="menu-overlay__link" href="#menu" data-menu-link data-menu-initial-focus>Меню</a>
-          </li>
-          <li>
-            <a class="menu-overlay__link" href="#booking" data-menu-link>Бронь</a>
-          </li>
-          <li>
-            <a class="menu-overlay__link" href="#history" data-menu-link>История</a>
-          </li>
-          <li>
-            <a class="menu-overlay__link" href="#contacts" data-menu-link>Контакты</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
+  <div
+    class="menu-overlay"
+    id="site-menu"
+    data-menu-overlay
+    aria-hidden="true"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="site-menu-title"
+  >
+    <nav class="menu-overlay__nav" aria-labelledby="site-menu-title">
+      <h2 class="visually-hidden" id="site-menu-title">Навигация</h2>
+      <ul class="menu-overlay__list">
+        <li>
+          <a class="menu-overlay__link" href="#menu" data-menu-link data-menu-initial-focus>Меню</a>
+        </li>
+        <li>
+          <a class="menu-overlay__link" href="#booking" data-menu-link>Бронь</a>
+        </li>
+        <li>
+          <a class="menu-overlay__link" href="#history" data-menu-link>История</a>
+        </li>
+        <li>
+          <a class="menu-overlay__link" href="#contacts" data-menu-link>Контакты</a>
+        </li>
+      </ul>
+    </nav>
   </div>
 
   <!-- Intro screen: centered title that scrolls away naturally -->

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
@@ -76,9 +77,7 @@
       "Мы начали с вопроса, который беспокоил нас самих: что действительно нужно человеку?",
       "Не каждому. Только тем, кто выбирает ясность вместо шума.",
       "Будущее дало ответ: энергия, фокус, равновесие.",
-      "Мы верим, что спокойствие и явность — это новая роскошь.",
-      "Жизнь можно проектировать.",
-      "Здоровье и фокус — это не случайность, а выбор, который вы делаете каждый день.",
+      "Мы верим, что спокойствие и явность — это новая роскошь. Жизнь можно проектировать. Здоровье и фокус — это не случайность, а выбор, который вы делаете каждый день.",
       "Раньше люди искали смысл. Сегодня мы ищем фокус."
     ];
     window.SITE_CONFIG = { SENTENCES };

--- a/index.html
+++ b/index.html
@@ -73,12 +73,12 @@
   <script>
     // === EDIT TEXT HERE (English copy) ===
     const SENTENCES = [
-      "In a world that can be cruel and unforgiving,",
-      "we, as young, curious, and brave kids, refuse to be daunted by its challenges.",
-      "We are born with an innate sense of curiosity, eager to explore and discover, even if it leads us into trouble.",
-      "Our youthful spirit drives us forward, pushing the boundaries of what is possible.",
-      "Despite the uncertainties and risks that accompany our curiosity, we embrace them wholeheartedly.",
-      "We understand that what we lack in experience, we make up for in daring."
+      "Мы начали с вопроса, который беспокоил нас самих: что действительно нужно человеку?",
+      "Не каждому. Только тем, кто выбирает ясность вместо шума.",
+      "Будущее дало ответ: энергия, фокус, равновесие.",
+      "Мы верим, что спокойствие и явность — это новая роскошь. Жизнь можно проектировать.",
+      "Здоровье и фокус — это не случайность, а выбор, который вы делаете каждый день.",
+      "Раньше люди искали смысл. Сегодня мы ищем фокус."
     ];
     window.SITE_CONFIG = { SENTENCES };
   </script>

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Classnoe Mesto</title>
+  <title>CLASSNOE MESTO</title>
   <meta name="description" content="A conceptual space. Scroll narrative." />
-  <meta property="og:title" content="Classnoe Mesto" />
+  <meta property="og:title" content="CLASSNOE MESTO" />
   <meta property="og:description" content="A conceptual space. Scroll narrative." />
   <meta property="og:type" content="website" />
   <meta name="theme-color" content="#1c1c1c" />
@@ -43,16 +43,16 @@
       <h2 class="visually-hidden" id="site-menu-title">Навигация</h2>
       <ul class="menu-overlay__list">
         <li>
-          <a class="menu-overlay__link" href="#menu" data-menu-link data-menu-initial-focus>Меню</a>
+          <a class="menu-overlay__link" href="#menu" data-menu-link data-menu-initial-focus>МЕНЮ</a>
         </li>
         <li>
-          <a class="menu-overlay__link" href="#booking" data-menu-link>Бронь</a>
+          <a class="menu-overlay__link" href="#booking" data-menu-link>БРОНЬ</a>
         </li>
         <li>
-          <a class="menu-overlay__link" href="#history" data-menu-link>История</a>
+          <a class="menu-overlay__link" href="#history" data-menu-link>ИСТОРИЯ</a>
         </li>
         <li>
-          <a class="menu-overlay__link" href="#contacts" data-menu-link>Контакты</a>
+          <a class="menu-overlay__link" href="#contacts" data-menu-link>КОНТАКТЫ</a>
         </li>
       </ul>
     </nav>
@@ -60,7 +60,7 @@
 
   <!-- Intro screen: centered title that scrolls away naturally -->
   <section id="intro" aria-label="Intro">
-    <h1>Classnoe Mesto</h1>
+    <h1>CLASSNOE MESTO</h1>
   </section>
 
   <!-- Scroll content; text appears progressively, sentence by sentence -->
@@ -76,7 +76,8 @@
       "Мы начали с вопроса, который беспокоил нас самих: что действительно нужно человеку?",
       "Не каждому. Только тем, кто выбирает ясность вместо шума.",
       "Будущее дало ответ: энергия, фокус, равновесие.",
-      "Мы верим, что спокойствие и явность — это новая роскошь. Жизнь можно проектировать.",
+      "Мы верим, что спокойствие и явность — это новая роскошь.",
+      "Жизнь можно проектировать.",
       "Здоровье и фокус — это не случайность, а выбор, который вы делаете каждый день.",
       "Раньше люди искали смысл. Сегодня мы ищем фокус."
     ];

--- a/script.js
+++ b/script.js
@@ -77,10 +77,19 @@
     });
   }
 
-  updateActiveSentence();
-  requestAnimationFrame(updateActiveSentence);
+  function scheduleInitialReveal() {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        updateActiveSentence();
+      });
+    });
+  }
+
+  scheduleInitialReveal();
+  window.addEventListener('load', scheduleInitialReveal, { once: true });
   window.addEventListener('scroll', requestUpdate, { passive: true });
   window.addEventListener('resize', requestUpdate);
+  window.addEventListener('orientationchange', requestUpdate);
 })();
 
 (function() {

--- a/script.js
+++ b/script.js
@@ -43,12 +43,18 @@
   }
 
   function updateActiveSentence() {
-    const viewportCenter = window.innerHeight / 2;
+    const viewportHeight = window.innerHeight;
+    const viewportCenter = viewportHeight / 2;
     let closestIndex = -1;
     let smallestDistance = Infinity;
 
     nodes.forEach((node, index) => {
       const rect = node.getBoundingClientRect();
+      const isInViewport = rect.bottom > 0 && rect.top < viewportHeight;
+      if (!isInViewport) {
+        return;
+      }
+
       const nodeCenter = rect.top + rect.height / 2;
       const distance = Math.abs(nodeCenter - viewportCenter);
 

--- a/script.js
+++ b/script.js
@@ -84,30 +84,11 @@
   }
 
   function lockScroll() {
-    const scrollY = window.scrollY || window.pageYOffset || 0;
-    document.body.dataset.menuScrollPosition = String(scrollY);
-    document.body.style.top = `-${scrollY}px`;
-    document.body.style.left = '0';
-    document.body.style.right = '0';
-    document.body.style.position = 'fixed';
-    document.body.style.width = '100%';
     document.body.classList.add('menu-open');
   }
 
   function unlockScroll() {
-    const stored = document.body.dataset.menuScrollPosition;
     document.body.classList.remove('menu-open');
-    document.body.style.removeProperty('top');
-    document.body.style.removeProperty('left');
-    document.body.style.removeProperty('right');
-    document.body.style.removeProperty('position');
-    document.body.style.removeProperty('width');
-
-    if (stored) {
-      const value = parseInt(stored, 10) || 0;
-      delete document.body.dataset.menuScrollPosition;
-      window.scrollTo(0, value);
-    }
   }
 
   function getFocusableElements() {

--- a/script.js
+++ b/script.js
@@ -1,60 +1,86 @@
 (function() {
   const { SENTENCES } = window.SITE_CONFIG || {};
+  if (!Array.isArray(SENTENCES) || SENTENCES.length === 0) return;
 
   const list = document.getElementById('sentences');
-  let scrollDirection = 0;  // Track scroll direction (up or down)
+  if (!list) return;
 
-  // Build sentence nodes
-  const nodes = SENTENCES.map((text, idx) => {
-    const p = document.createElement('p');
-    p.className = 'sentence';
-    p.textContent = text;
-    p.setAttribute('role', 'listitem');
-    p.setAttribute('aria-setsize', SENTENCES.length);
-    p.setAttribute('aria-posinset', String(idx + 1));
-    list.appendChild(p);
-    return p;
+  const total = SENTENCES.length;
+  const nodes = SENTENCES.map((text, index) => {
+    const sentence = document.createElement('p');
+    sentence.className = 'sentence';
+    sentence.textContent = text;
+    sentence.setAttribute('role', 'listitem');
+    sentence.setAttribute('aria-setsize', total);
+    sentence.setAttribute('aria-posinset', String(index + 1));
+    list.appendChild(sentence);
+    return sentence;
   });
 
-  // IntersectionObserver for sentence visibility based on scrolling
-  const io = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      const el = entry.target;
-      if (entry.isIntersecting) {
-        el.classList.add('visible');
-        // Dim previous sentences one by one
-        const idx = nodes.indexOf(el);
-        nodes.forEach((node, i) => {
-          if (i < idx) node.classList.add('dimmed');
-        });
+  let activeIndex = -1;
+  const revealed = new Set();
+  let ticking = false;
+
+  function applyStates(currentIndex) {
+    nodes.forEach((node, index) => {
+      const isActive = index === currentIndex;
+      const isPast = index < currentIndex;
+      const hasBeenRevealed = revealed.has(index) || isPast || isActive;
+
+      if (isPast) {
+        revealed.add(index);
+      }
+
+      node.classList.toggle('is-active', isActive);
+      node.classList.toggle('is-past', isPast);
+      node.classList.toggle('is-visible', hasBeenRevealed);
+
+      if (!hasBeenRevealed) {
+        node.classList.remove('is-past');
+        node.classList.remove('is-active');
       }
     });
-  }, { root: null, rootMargin: '0px 0px -45% 0px', threshold: 0.4 });
+  }
 
-  nodes.forEach(n => io.observe(n));
+  function updateActiveSentence() {
+    const viewportCenter = window.innerHeight / 2;
+    let closestIndex = -1;
+    let smallestDistance = Infinity;
 
-  // Scroll direction tracking (up or down) and text fade out
-  let lastScrollY = window.scrollY;
-  window.addEventListener('scroll', () => {
-    if (window.scrollY > lastScrollY) {
-      // Scrolling down: text becomes brighter
-      scrollDirection = 1;
-    } else {
-      // Scrolling up: text disappears one by one
-      scrollDirection = -1;
+    nodes.forEach((node, index) => {
+      const rect = node.getBoundingClientRect();
+      const nodeCenter = rect.top + rect.height / 2;
+      const distance = Math.abs(nodeCenter - viewportCenter);
+
+      if (distance < smallestDistance) {
+        smallestDistance = distance;
+        closestIndex = index;
+      }
+    });
+
+    if (closestIndex === -1) return;
+
+    if (!revealed.has(closestIndex)) {
+      revealed.add(closestIndex);
     }
-    lastScrollY = window.scrollY;
-    // Apply fade effects
-    nodes.forEach((node, i) => {
-      if (scrollDirection === -1) {
-        node.style.opacity = 0;
-        node.style.transform = 'translateY(12px)';
-      } else {
-        node.style.opacity = 1;
-        node.style.transform = 'translateY(0)';
-      }
+
+    activeIndex = closestIndex;
+    applyStates(activeIndex);
+  }
+
+  function requestUpdate() {
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(() => {
+      ticking = false;
+      updateActiveSentence();
     });
-  });
+  }
+
+  updateActiveSentence();
+  requestAnimationFrame(updateActiveSentence);
+  window.addEventListener('scroll', requestUpdate, { passive: true });
+  window.addEventListener('resize', requestUpdate);
 })();
 
 (function() {

--- a/script.js
+++ b/script.js
@@ -63,7 +63,6 @@
   if (!toggle || !overlay) return;
 
   const toggleLabel = toggle.querySelector('[data-menu-toggle-label]');
-  const closeButtons = overlay.querySelectorAll('[data-menu-close]');
   const menuLinks = overlay.querySelectorAll('[data-menu-link]');
   const initialFocusTarget = overlay.querySelector('[data-menu-initial-focus]');
   const focusableSelector = [
@@ -187,10 +186,6 @@
     if (event.target === overlay) {
       closeMenu();
     }
-  });
-
-  closeButtons.forEach(btn => {
-    btn.addEventListener('click', closeMenu);
   });
 
   menuLinks.forEach(link => {

--- a/script.js
+++ b/script.js
@@ -56,3 +56,167 @@
     });
   });
 })();
+
+(function() {
+  const toggle = document.querySelector('[data-menu-toggle]');
+  const overlay = document.querySelector('[data-menu-overlay]');
+  if (!toggle || !overlay) return;
+
+  const toggleLabel = toggle.querySelector('[data-menu-toggle-label]');
+  const closeButtons = overlay.querySelectorAll('[data-menu-close]');
+  const menuLinks = overlay.querySelectorAll('[data-menu-link]');
+  const initialFocusTarget = overlay.querySelector('[data-menu-initial-focus]');
+  const focusableSelector = [
+    'a[href]:not([tabindex="-1"])',
+    'button:not([disabled]):not([tabindex="-1"])',
+    'input:not([disabled]):not([tabindex="-1"])',
+    'select:not([disabled]):not([tabindex="-1"])',
+    'textarea:not([disabled]):not([tabindex="-1"])',
+    '[tabindex]:not([tabindex="-1"])'
+  ].join(',');
+
+  let lastFocusedElement = null;
+
+  function setToggleLabel(isOpen) {
+    const label = isOpen ? 'Закрыть меню' : 'Открыть меню';
+    if (toggleLabel) toggleLabel.textContent = label;
+    toggle.setAttribute('aria-label', label);
+  }
+
+  function lockScroll() {
+    const scrollY = window.scrollY || window.pageYOffset || 0;
+    document.body.dataset.menuScrollPosition = String(scrollY);
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.left = '0';
+    document.body.style.right = '0';
+    document.body.style.position = 'fixed';
+    document.body.style.width = '100%';
+    document.body.classList.add('menu-open');
+  }
+
+  function unlockScroll() {
+    const stored = document.body.dataset.menuScrollPosition;
+    document.body.classList.remove('menu-open');
+    document.body.style.removeProperty('top');
+    document.body.style.removeProperty('left');
+    document.body.style.removeProperty('right');
+    document.body.style.removeProperty('position');
+    document.body.style.removeProperty('width');
+
+    if (stored) {
+      const value = parseInt(stored, 10) || 0;
+      delete document.body.dataset.menuScrollPosition;
+      window.scrollTo(0, value);
+    }
+  }
+
+  function getFocusableElements() {
+    const elements = Array.from(overlay.querySelectorAll(focusableSelector));
+    return elements.filter(el => {
+      if (el.hasAttribute('disabled')) return false;
+      if (el.getAttribute('aria-hidden') === 'true') return false;
+      return el.offsetParent !== null || el instanceof SVGElement;
+    });
+  }
+
+  function handleKeydown(event) {
+    if (!overlay.classList.contains('is-open')) return;
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeMenu();
+      return;
+    }
+
+    if (event.key !== 'Tab') return;
+
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey) {
+      if (active === first || active === overlay) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function openMenu() {
+    if (overlay.classList.contains('is-open')) return;
+
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    overlay.classList.add('is-open');
+    overlay.setAttribute('aria-hidden', 'false');
+    toggle.classList.add('is-active');
+    toggle.setAttribute('aria-expanded', 'true');
+    toggle.setAttribute('tabindex', '-1');
+    setToggleLabel(true);
+    lockScroll();
+
+    document.addEventListener('keydown', handleKeydown);
+
+    requestAnimationFrame(() => {
+      const fallback = getFocusableElements()[0];
+      const target = initialFocusTarget instanceof HTMLElement ? initialFocusTarget : fallback;
+      if (target) target.focus();
+    });
+  }
+
+  function closeMenu() {
+    if (!overlay.classList.contains('is-open')) return;
+
+    overlay.classList.remove('is-open');
+    overlay.setAttribute('aria-hidden', 'true');
+    toggle.classList.remove('is-active');
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.removeAttribute('tabindex');
+    setToggleLabel(false);
+    document.removeEventListener('keydown', handleKeydown);
+    unlockScroll();
+
+    const returnFocusTarget = lastFocusedElement && typeof lastFocusedElement.focus === 'function'
+      ? lastFocusedElement
+      : toggle;
+
+    requestAnimationFrame(() => {
+      returnFocusTarget.focus();
+    });
+  }
+
+  toggle.addEventListener('click', () => {
+    if (overlay.classList.contains('is-open')) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  });
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) {
+      closeMenu();
+    }
+  });
+
+  closeButtons.forEach(btn => {
+    btn.addEventListener('click', closeMenu);
+  });
+
+  menuLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      closeMenu();
+    });
+  });
+
+  setToggleLabel(false);
+})();

--- a/styles.css
+++ b/styles.css
@@ -187,36 +187,71 @@ body.menu-open {
 }
 
 /* Scroll zone */
-#scroll-zone { padding: 0 6vw; }
+#scroll-zone {
+  padding: 0;
+  perspective: 1300px;
+}
+
 #sentences {
   position: relative;
-  width: min(1400px, 94vw);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: min(1100px, 100%);
   margin: 0 auto;
-  padding-top: 6vh;
-  padding-bottom: 40vh;
+  padding: clamp(96px, 28vh, 320px) clamp(18px, 6vw, 120px) clamp(160px, 40vh, 420px);
+  perspective: inherit;
 }
 
 /* Sentence states */
 .sentence {
-  margin: 0;
-  font-size: clamp(28px, 4.8vw, 72px);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  width: 100%;
+  max-width: 860px;
+  margin: 0 auto;
+  padding-inline: clamp(12px, 6vw, 80px);
+  text-align: center;
+  font-size: clamp(26px, 5.2vw, 72px);
   font-weight: 800;
-  letter-spacing: -0.01em;
-  line-height: 1.15;
-  color: rgba(255,255,255,0);
+  letter-spacing: -0.012em;
+  line-height: 1.18;
+  color: rgba(255, 255, 255, 0.08);
   opacity: 0;
-  transform: translateY(12px);
-  transition: opacity 900ms ease, color 900ms ease, transform 900ms ease;
-  will-change: opacity, color, transform;
+  filter: blur(28px);
+  transform: translate3d(0, 160px, -280px) scale(0.84);
+  transition:
+    opacity 760ms ease,
+    filter 760ms ease,
+    transform 760ms cubic-bezier(0.25, 0.7, 0.3, 1),
+    color 760ms ease;
+  will-change: opacity, transform, filter, color;
+  backface-visibility: hidden;
+  text-wrap: balance;
 }
-.sentence.visible {
+
+.sentence.is-visible {
+  opacity: 0.38;
+  color: rgba(255, 255, 255, 0.46);
+  filter: blur(18px);
+  transform: translate3d(0, 90px, -160px) scale(0.9);
+}
+
+.sentence.is-past {
+  opacity: 0.2;
+  color: rgba(255, 255, 255, 0.26);
+  filter: blur(22px);
+  transform: translate3d(0, -60px, -240px) scale(0.88);
+}
+
+.sentence.is-active {
   opacity: 1;
-  color: rgba(255,255,255,0.95);  /* brighter active text */
-  transform: translateY(0);
-}
-.sentence.dimmed {             /* previous sentences disappear one-by-one on scroll up */
-  color: rgba(255,255,255,0.1);
-  opacity: 0;
+  color: rgba(255, 255, 255, 0.98);
+  filter: blur(0);
+  transform: translate3d(0, 0, 0) scale(1);
 }
 
 /* Accessibility */

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
 html, body { height: 100%; margin: 0; }
 html { scroll-behavior: smooth; }
 body {
-  font-family: 'Manrope', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Roboto', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background: #1e1e1e;
   color: #f2f2f2;
   line-height: 1.45;
@@ -155,7 +155,7 @@ body.menu-open {
   padding: 10px 16px;
   border-radius: 12px;
   transition: color 220ms ease, background 220ms ease;
-  font-family: 'Inter', 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Roboto', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .menu-overlay__link:focus-visible,
@@ -178,16 +178,16 @@ body.menu-open {
 }
 #intro h1 {
   margin: 0;
-  font-size: clamp(30px, 6vw, 80px);
-  font-weight: 600;
-  letter-spacing: 0.24em;
+  font-size: clamp(16px, 5.5vw, 82px);
+  font-weight: 800;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.85);
+  color: rgba(255, 255, 255, 0.88);
   text-align: center;
-  line-height: 1.2;
-  padding-left: 10vw;
-  padding-right: 10vw;
-  font-family: 'Inter', 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.1;
+  padding-inline: clamp(8px, 3vw, 48px);
+  font-family: 'Inter', 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  white-space: nowrap;
 }
 
 /* Scroll zone */
@@ -223,7 +223,7 @@ body.menu-open {
   font-weight: 500;
   letter-spacing: -0.01em;
   line-height: 1.35;
-  font-family: 'Manrope', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Roboto', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: rgba(255, 255, 255, 0.08);
   opacity: 0;
   filter: blur(28px);

--- a/styles.css
+++ b/styles.css
@@ -113,93 +113,23 @@ body.menu-open {
   transition: opacity 650ms ease, visibility 0s;
 }
 
-.menu-overlay__surface {
-  position: relative;
-  flex: 0 1 auto;
-  width: min(360px, 90vw);
-  margin: 0;
-  padding: clamp(24px, 6vw, 32px) clamp(20px, 5vw, 32px);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: clamp(16px, 4vh, 24px);
-  color: rgba(255, 255, 255, 0.9);
-  background: #161616;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
-  text-align: center;
-  transform: translateY(16px);
-  opacity: 0;
-  transition: transform 520ms ease, opacity 520ms ease;
-}
-
-.menu-overlay.is-open .menu-overlay__surface {
-  transform: translateY(0);
-  opacity: 1;
-}
-
-.menu-overlay__close {
-  position: absolute;
-  top: clamp(8px, 3vw, 16px);
-  right: clamp(8px, 3vw, 16px);
-  width: 44px;
-  height: 44px;
-  min-width: 44px;
-  min-height: 44px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.08);
-  color: inherit;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 240ms ease, border-color 240ms ease;
-}
-
-.menu-overlay__close:hover,
-.menu-overlay__close:focus-visible {
-  background: rgba(255, 255, 255, 0.16);
-  border-color: rgba(255, 255, 255, 0.32);
-}
-
-.menu-overlay__close:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.6);
-  outline-offset: 4px;
-}
-
-.menu-overlay__close-icon {
-  position: relative;
-  width: 18px;
-  height: 18px;
-}
-
-.menu-overlay__close-icon::before,
-.menu-overlay__close-icon::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 100%;
-  height: 2px;
-  background: currentColor;
-  border-radius: 999px;
-}
-
-.menu-overlay__close-icon::before {
-  transform: translateY(-50%) rotate(45deg);
-}
-
-.menu-overlay__close-icon::after {
-  transform: translateY(-50%) rotate(-45deg);
-}
-
 .menu-overlay__nav {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: clamp(12px, 2vh, 20px);
+  justify-content: center;
+  gap: clamp(14px, 3vh, 22px);
+  width: min(320px, 90vw);
+  color: rgba(255, 255, 255, 0.9);
+  text-align: center;
+  transform: translateY(20px);
+  opacity: 0;
+  transition: transform 520ms ease, opacity 520ms ease;
+}
+
+.menu-overlay.is-open .menu-overlay__nav {
+  transform: translateY(0);
+  opacity: 1;
 }
 
 .menu-overlay__list {
@@ -235,18 +165,6 @@ body.menu-open {
 .menu-overlay__link:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.35);
   outline-offset: 2px;
-}
-
-@media (max-width: 640px) {
-  .menu-overlay__surface {
-    width: min(320px, 92vw);
-    padding: clamp(20px, 8vw, 28px) clamp(16px, 8vw, 24px);
-  }
-
-  .menu-overlay__close {
-    top: 12px;
-    right: 12px;
-  }
 }
 
 /* Intro screen (not fixed anymore) */

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,255 @@ body {
   overflow-x: hidden;
 }
 
+body.menu-open {
+  overflow: hidden;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Menu toggle (hamburger) */
+.menu-toggle {
+  position: fixed;
+  top: clamp(16px, 4vw, 32px);
+  right: clamp(16px, 4vw, 32px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #f2f2f2;
+  cursor: pointer;
+  transition: background 260ms ease, border-color 260ms ease;
+  z-index: 120;
+}
+
+.menu-toggle:hover,
+.menu-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.24);
+}
+
+.menu-toggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 4px;
+}
+
+.menu-toggle__icon {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  gap: 6px;
+}
+
+.menu-toggle__bar {
+  width: 20px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform 420ms ease, opacity 420ms ease;
+}
+
+.menu-toggle.is-active .menu-toggle__bar:nth-child(1) {
+  transform: translateY(8px) rotate(45deg);
+}
+
+.menu-toggle.is-active .menu-toggle__bar:nth-child(2) {
+  opacity: 0;
+}
+
+.menu-toggle.is-active .menu-toggle__bar:nth-child(3) {
+  transform: translateY(-8px) rotate(-45deg);
+}
+
+/* Menu overlay */
+.menu-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  padding: 0;
+  background: rgba(12, 12, 12, 0.86);
+  backdrop-filter: blur(8px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 650ms ease, visibility 0s linear 650ms;
+  z-index: 110;
+}
+
+.menu-overlay.is-open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity 650ms ease, visibility 0s;
+}
+
+.menu-overlay__surface {
+  position: relative;
+  flex: 1;
+  max-width: 720px;
+  margin: 0;
+  padding: clamp(72px, 12vh, 140px) clamp(32px, 9vw, 160px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(40px, 8vh, 96px);
+  color: rgba(255, 255, 255, 0.92);
+  transform: translateY(24px);
+  opacity: 0;
+  transition: transform 650ms ease, opacity 650ms ease;
+}
+
+.menu-overlay.is-open .menu-overlay__surface {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.menu-overlay__close {
+  position: absolute;
+  top: clamp(16px, 4vw, 32px);
+  right: clamp(16px, 4vw, 32px);
+  width: 48px;
+  height: 48px;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 260ms ease, border-color 260ms ease;
+}
+
+.menu-overlay__close:hover,
+.menu-overlay__close:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.32);
+}
+
+.menu-overlay__close:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 4px;
+}
+
+.menu-overlay__close-icon {
+  position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+.menu-overlay__close-icon::before,
+.menu-overlay__close-icon::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+}
+
+.menu-overlay__close-icon::before {
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.menu-overlay__close-icon::after {
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.menu-overlay__nav {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(32px, 6vh, 72px);
+}
+
+.menu-overlay__title {
+  margin: 0;
+  font-size: clamp(32px, 6vw, 72px);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.menu-overlay__subtitle {
+  margin: 0;
+  font-size: clamp(16px, 2.4vw, 22px);
+  color: rgba(255, 255, 255, 0.56);
+  max-width: 32ch;
+}
+
+.menu-overlay__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 4vh, 42px);
+}
+
+.menu-overlay__link {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: clamp(30px, 5vw, 58px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  transition: color 320ms ease;
+}
+
+.menu-overlay__link:focus-visible,
+.menu-overlay__link:hover {
+  color: rgba(255, 255, 255, 1);
+}
+
+.menu-overlay__link:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 6px;
+}
+
+.menu-overlay__note {
+  font-size: clamp(12px, 2.2vw, 14px);
+  font-weight: 400;
+  letter-spacing: 0;
+  color: rgba(255, 255, 255, 0.56);
+}
+
+@media (max-width: 640px) {
+  .menu-overlay__surface {
+    padding: clamp(56px, 10vh, 96px) clamp(20px, 8vw, 64px);
+  }
+
+  .menu-overlay__close {
+    top: clamp(12px, 4vw, 24px);
+    right: clamp(12px, 4vw, 24px);
+  }
+}
+
 /* Intro screen (not fixed anymore) */
 #intro {
   min-height: 100vh;

--- a/styles.css
+++ b/styles.css
@@ -147,10 +147,11 @@ body.menu-open {
   align-items: center;
   justify-content: center;
   font-size: clamp(18px, 3.6vw, 22px);
-  font-weight: 500;
-  letter-spacing: -0.005em;
+  font-weight: 600;
+  letter-spacing: 0.18em;
   color: rgba(255, 255, 255, 0.88);
   text-decoration: none;
+  text-transform: uppercase;
   padding: 10px 16px;
   border-radius: 12px;
   transition: color 220ms ease, background 220ms ease;
@@ -178,7 +179,8 @@ body.menu-open {
   margin: 0;
   font-size: clamp(30px, 6vw, 80px);
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
   color: rgba(255,255,255,0.85);
   text-align: center;
   line-height: 1.2;

--- a/styles.css
+++ b/styles.css
@@ -98,8 +98,7 @@ body.menu-open {
   justify-content: center;
   align-items: center;
   padding: clamp(24px, 6vw, 48px);
-  background: rgba(12, 12, 12, 0.86);
-  backdrop-filter: blur(8px);
+  background: #090909;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -122,12 +121,14 @@ body.menu-open {
   padding: clamp(24px, 6vw, 32px) clamp(20px, 5vw, 32px);
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: clamp(16px, 4vh, 24px);
   color: rgba(255, 255, 255, 0.9);
-  background: rgba(22, 22, 22, 0.95);
+  background: #161616;
   border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  text-align: center;
   transform: translateY(16px);
   opacity: 0;
   transition: transform 520ms ease, opacity 520ms ease;
@@ -197,6 +198,7 @@ body.menu-open {
 .menu-overlay__nav {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: clamp(12px, 2vh, 20px);
 }
 
@@ -206,19 +208,20 @@ body.menu-open {
   padding: 0;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: clamp(12px, 2vh, 18px);
 }
 
 .menu-overlay__link {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   font-size: clamp(18px, 3.6vw, 22px);
   font-weight: 500;
   letter-spacing: -0.005em;
   color: rgba(255, 255, 255, 0.88);
   text-decoration: none;
-  padding: 10px 12px;
+  padding: 10px 16px;
   border-radius: 12px;
   transition: color 220ms ease, background 220ms ease;
 }

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
 html, body { height: 100%; margin: 0; }
 html { scroll-behavior: smooth; }
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Manrope', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: #1e1e1e;
   color: #f2f2f2;
   line-height: 1.45;
@@ -155,6 +155,7 @@ body.menu-open {
   padding: 10px 16px;
   border-radius: 12px;
   transition: color 220ms ease, background 220ms ease;
+  font-family: 'Inter', 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 .menu-overlay__link:focus-visible,
@@ -186,6 +187,7 @@ body.menu-open {
   line-height: 1.2;
   padding-left: 10vw;
   padding-right: 10vw;
+  font-family: 'Inter', 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 /* Scroll zone */
@@ -217,10 +219,11 @@ body.menu-open {
   margin: 0 auto;
   padding-inline: clamp(12px, 6vw, 80px);
   text-align: center;
-  font-size: clamp(26px, 5.2vw, 72px);
-  font-weight: 800;
-  letter-spacing: -0.012em;
-  line-height: 1.18;
+  font-size: clamp(20px, 3.6vw, 48px);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.35;
+  font-family: 'Manrope', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   color: rgba(255, 255, 255, 0.08);
   opacity: 0;
   filter: blur(28px);

--- a/styles.css
+++ b/styles.css
@@ -96,8 +96,8 @@ body.menu-open {
   inset: 0;
   display: flex;
   justify-content: center;
-  align-items: stretch;
-  padding: 0;
+  align-items: center;
+  padding: clamp(24px, 6vw, 48px);
   background: rgba(12, 12, 12, 0.86);
   backdrop-filter: blur(8px);
   opacity: 0;
@@ -116,17 +116,21 @@ body.menu-open {
 
 .menu-overlay__surface {
   position: relative;
-  flex: 1;
-  max-width: 720px;
+  flex: 0 1 auto;
+  width: min(360px, 90vw);
   margin: 0;
-  padding: clamp(72px, 12vh, 140px) clamp(32px, 9vw, 160px);
+  padding: clamp(24px, 6vw, 32px) clamp(20px, 5vw, 32px);
   display: flex;
   flex-direction: column;
-  gap: clamp(40px, 8vh, 96px);
-  color: rgba(255, 255, 255, 0.92);
-  transform: translateY(24px);
+  gap: clamp(16px, 4vh, 24px);
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(22, 22, 22, 0.95);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  transform: translateY(16px);
   opacity: 0;
-  transition: transform 650ms ease, opacity 650ms ease;
+  transition: transform 520ms ease, opacity 520ms ease;
 }
 
 .menu-overlay.is-open .menu-overlay__surface {
@@ -136,21 +140,21 @@ body.menu-open {
 
 .menu-overlay__close {
   position: absolute;
-  top: clamp(16px, 4vw, 32px);
-  right: clamp(16px, 4vw, 32px);
-  width: 48px;
-  height: 48px;
+  top: clamp(8px, 3vw, 16px);
+  right: clamp(8px, 3vw, 16px);
+  width: 44px;
+  height: 44px;
   min-width: 44px;
   min-height: 44px;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.08);
   color: inherit;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 260ms ease, border-color 260ms ease;
+  transition: background 240ms ease, border-color 240ms ease;
 }
 
 .menu-overlay__close:hover,
@@ -193,22 +197,7 @@ body.menu-open {
 .menu-overlay__nav {
   display: flex;
   flex-direction: column;
-  gap: clamp(32px, 6vh, 72px);
-}
-
-.menu-overlay__title {
-  margin: 0;
-  font-size: clamp(32px, 6vw, 72px);
-  font-weight: 800;
-  letter-spacing: -0.01em;
-  color: rgba(255, 255, 255, 0.92);
-}
-
-.menu-overlay__subtitle {
-  margin: 0;
-  font-size: clamp(16px, 2.4vw, 22px);
-  color: rgba(255, 255, 255, 0.56);
-  max-width: 32ch;
+  gap: clamp(12px, 2vh, 20px);
 }
 
 .menu-overlay__list {
@@ -217,47 +206,43 @@ body.menu-open {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: clamp(20px, 4vh, 42px);
+  gap: clamp(12px, 2vh, 18px);
 }
 
 .menu-overlay__link {
-  position: relative;
   display: inline-flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: clamp(30px, 5vw, 58px);
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: rgba(255, 255, 255, 0.9);
+  align-items: center;
+  justify-content: flex-start;
+  font-size: clamp(18px, 3.6vw, 22px);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: rgba(255, 255, 255, 0.88);
   text-decoration: none;
-  transition: color 320ms ease;
+  padding: 10px 12px;
+  border-radius: 12px;
+  transition: color 220ms ease, background 220ms ease;
 }
 
 .menu-overlay__link:focus-visible,
 .menu-overlay__link:hover {
   color: rgba(255, 255, 255, 1);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .menu-overlay__link:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.6);
-  outline-offset: 6px;
-}
-
-.menu-overlay__note {
-  font-size: clamp(12px, 2.2vw, 14px);
-  font-weight: 400;
-  letter-spacing: 0;
-  color: rgba(255, 255, 255, 0.56);
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 2px;
 }
 
 @media (max-width: 640px) {
   .menu-overlay__surface {
-    padding: clamp(56px, 10vh, 96px) clamp(20px, 8vw, 64px);
+    width: min(320px, 92vw);
+    padding: clamp(20px, 8vw, 28px) clamp(16px, 8vw, 24px);
   }
 
   .menu-overlay__close {
-    top: clamp(12px, 4vw, 24px);
-    right: clamp(12px, 4vw, 24px);
+    top: 12px;
+    right: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add hamburger toggle button and overlay navigation markup for core sections
- style the full-screen overlay with menu typography, transitions, and accessibility cues
- implement JavaScript to toggle the menu, trap focus, and lock background scroll

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc57b4c9b4833185d09fb009316a05